### PR TITLE
Use PRNG to generate unique pad name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # ep_message_all
-Etherpad lite plugin to create a really new pad. It checks if a random string (between 8 and 15 characters) already exists in database. If not it will redirect the user to this page and create the pad.
+Etherpad lite plugin to create a really new pad. It uses the PRNG from Node.js Crypto module to generate a pseudorandom string with 20 characters and create the pad.
 
 Call http://example.com/randomPad to create a random pad.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ep_new_pad",
-  "version": "0.0.1",
-  "description": "Etherpad lite plugin to crate a REALLY new pad (database check). Call http://example.com/randomPad to use it.",
+  "version": "0.0.2",
+  "description": "Etherpad lite plugin to crate a REALLY new pad (using PRNG). Call http://example.com/randomPad to use it.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
This modification uses the same reasoning as the modification made in
Etherpad Lite random pad name generation:

  ether/etherpad-lite#3516
  ether/etherpad-lite#3517

Closes: #2