### PR TITLE
Use relative path so it works if the installation isn't in document root

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ exports.registerRoute = function (hook_name, args, cb) {
         padName = createRandomPadName();
         // redirect to new pad
         res.writeHead(302, {
-          'Location': '/p/'+padName
+          'Location': 'p/'+padName
         });
         res.end();
         callback();


### PR DESCRIPTION
If you have etherpad behind a proxy for ex. /etherpad the current solution redirects to a non-existing path. With using a relative path it works